### PR TITLE
Improve config for building on DockerHub

### DIFF
--- a/docker-c6/Dockerfile
+++ b/docker-c6/Dockerfile
@@ -30,10 +30,7 @@ RUN yum -y install glexec mkgltempdir \
                    lcas lcas-plugins-basic lcas-plugins-voms
 
 # Machine job features
-RUN yum -y install wget
-RUN wget --no-check-certificate https://repo.gridpp.ac.uk/machinejobfeatures/mjf-scripts/00/RPMS/mjf-htcondor-00.14-1.noarch.rpm && \
-    yum -y localinstall mjf-htcondor-00.14-1.noarch.rpm && \
-    rm -f mjf-htcondor-00.14-1.noarch.rpm
+RUN yum -y install http://quattor.web.lal.in2p3.fr/packages/machine-job-features/sl6/noarch/mjf-htcondor-00.19-1.noarch.rpm
 
 # Boost
 RUN yum -y install boost-date-time boost-filesystem boost-graph boost-iostreams boost-program-options \

--- a/docker-c6/Dockerfile
+++ b/docker-c6/Dockerfile
@@ -38,8 +38,8 @@ RUN yum -y install boost-date-time boost-filesystem boost-graph boost-iostreams 
                    boost-thread boost-wave
 
 # Singularity
-RUN yum -y install http://mirrors.gridpp.rl.ac.uk/current/epel-6-x86_64/RPMS.base/singularity-2.6.1-1.1.el6.x86_64.rpm \
-                   http://mirrors.gridpp.rl.ac.uk/current/epel-6-x86_64/RPMS.base/singularity-runtime-2.6.1-1.1.el6.x86_64.rpm
+RUN yum -y install singularity-2.6.1-1.1.el6.x86_64 \
+                   singularity-runtime-2.6.1-1.1.el6.x86_64
 
 RUN sed -i '/enable overlay/c\enable overlay = no' /etc/singularity/singularity.conf
 

--- a/docker-c6/Dockerfile
+++ b/docker-c6/Dockerfile
@@ -50,7 +50,8 @@ RUN sed -i '/max loop devices/c\max loop devices = 0' /etc/singularity/singulari
 
 # Update & cleanup
 RUN yum -y update && \
-    yum clean all
+    yum clean all && \
+    rm -rf /var/cache/yum
 
 # glexec
 RUN mkdir -p /opt/glite/sbin && ln -s /usr/sbin/glexec /opt/glite/sbin/glexec

--- a/docker-c7/Dockerfile
+++ b/docker-c7/Dockerfile
@@ -19,10 +19,7 @@ RUN yum -y install freetype expat gcc glibc-headers compat-expat1 compat-openlda
 RUN yum -y install http://linuxsoft.cern.ch/wlcg/centos7/x86_64/HEP_OSlibs-7.2.6-1.el7.cern.x86_64.rpm
 
 # Machine job features
-RUN yum -y install wget
-RUN wget --no-check-certificate https://repo.gridpp.ac.uk/machinejobfeatures/mjf-scripts/00/RPMS/mjf-htcondor-00.14-1.noarch.rpm && \
-    yum -y localinstall mjf-htcondor-00.14-1.noarch.rpm && \
-    rm -f mjf-htcondor-00.14-1.noarch.rpm
+RUN yum -y install http://quattor.web.lal.in2p3.fr/packages/machine-job-features/sl6/noarch/mjf-htcondor-00.19-1.noarch.rpm
 
 # Boost (need to ensure gfal CLI from CVMFS will work for some VOs)
 RUN yum -y install boost-date-time boost-filesystem boost-graph boost-iostreams boost-program-options \

--- a/docker-c7/Dockerfile
+++ b/docker-c7/Dockerfile
@@ -39,4 +39,5 @@ RUN sed -i '/max loop devices/c\max loop devices = 0' /etc/singularity/singulari
 
 # Update & cleanup
 RUN yum -y update && \
-    yum clean all
+    yum clean all && \
+    rm -rf /var/cache/yum

--- a/docker-c7/Dockerfile
+++ b/docker-c7/Dockerfile
@@ -27,8 +27,8 @@ RUN yum -y install boost-date-time boost-filesystem boost-graph boost-iostreams 
                    boost-thread boost-wave
 
 # Singularity
-RUN yum -y install http://mirrors.gridpp.rl.ac.uk/current/epel-7-x86_64/RPMS.base/singularity-2.6.1-1.1.el7.x86_64.rpm \
-                   http://mirrors.gridpp.rl.ac.uk/current/epel-7-x86_64/RPMS.base/singularity-runtime-2.6.1-1.1.el7.x86_64.rpm
+RUN yum -y install singularity-2.6.1-1.1.el7.x86_64 \
+                   singularity-runtime-2.6.1-1.1.el7.x86_64
 
 RUN sed -i '/enable overlay/c\enable overlay = no' /etc/singularity/singularity.conf
 


### PR DESCRIPTION
Our Dockerfiles were written assuming that they would be built inside our infrastructure and made use of local resources, this is not necessary to build the images and in fact prevents us making use of automatic builds on DockerHub. This PR removes the use of local resources and makes a couple of other improvements.