### PR TITLE
Specify version of CVMFS to be used

### DIFF
--- a/docker-c6/Dockerfile
+++ b/docker-c6/Dockerfile
@@ -8,7 +8,7 @@ RUN yum -y install zip
 # Install cvmfs-x509-helper for access to secure CVMFS repositories
 RUN yum -y install https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm \
                    https://ecsft.cern.ch/dist/cvmfs/cvmfs-config-egi/cvmfs-config-egi-2.0-1.el6.noarch.rpm  && \
-    yum -y install cvmfs && \
+    yum -y install cvmfs-2.5.2-1.el6.x86_64 && \
     yum -y install https://ecsft.cern.ch/dist/cvmfs/cvmfs-x509-helper/cvmfs-x509-helper-1.0-1.el6.x86_64.rpm
 
 # EPEL

--- a/docker-c7/Dockerfile
+++ b/docker-c7/Dockerfile
@@ -7,7 +7,7 @@ RUN yum -y install zip
 # CVMFS (for SUM tests only; install before adding other repos to ensure we have the latest version)
 RUN yum -y install https://ecsft.cern.ch/dist/cvmfs/cvmfs-release/cvmfs-release-latest.noarch.rpm \
                    https://ecsft.cern.ch/dist/cvmfs/cvmfs-config-egi/cvmfs-config-egi-2.0-1.el7.centos.noarch.rpm && \
-    yum -y install cvmfs
+    yum -y install cvmfs-2.5.2-1.el7.x86_64
 
 # EPEL
 RUN yum -y install https://dl.fedoraproject.org/pub/epel/epel-release-latest-7.noarch.rpm


### PR DESCRIPTION
This cannot be too far away from our CVMFS infrastructure without breaking things, so we really should control it.

Resolves #7.