### PR TITLE
Enable Singularity underlay support

### DIFF
--- a/docker-c6/Dockerfile
+++ b/docker-c6/Dockerfile
@@ -50,9 +50,9 @@ RUN yummy singularity-2.6.1-1.1.el6.x86_64 \
                    singularity-runtime-2.6.1-1.1.el6.x86_64
 
 # Disable overlay and loop device management in singularity
-RUN sed -i '/enable overlay/c\enable overlay = no' /etc/singularity/singularity.conf
-
-RUN sed -i '/max loop devices/c\max loop devices = 0' /etc/singularity/singularity.conf
+RUN sed -i '/enable overlay/c\enable overlay = no' /etc/singularity/singularity.conf && \
+    sed -i '/enable underlay/c\enable underlay = yes' /etc/singularity/singularity.conf && \
+    sed -i '/max loop devices/c\max loop devices = 0' /etc/singularity/singularity.conf
 
 # Update & cleanup
 RUN yum -y update && \

--- a/docker-c7/Dockerfile
+++ b/docker-c7/Dockerfile
@@ -40,9 +40,9 @@ RUN yummy singularity-2.6.1-1.1.el7.x86_64 \
                    singularity-runtime-2.6.1-1.1.el7.x86_64
 
 # Disable overlay and loop device management in singularity
-RUN sed -i '/enable overlay/c\enable overlay = no' /etc/singularity/singularity.conf
-
-RUN sed -i '/max loop devices/c\max loop devices = 0' /etc/singularity/singularity.conf
+RUN sed -i '/enable overlay/c\enable overlay = no' /etc/singularity/singularity.conf && \
+    sed -i '/enable underlay/c\enable underlay = yes' /etc/singularity/singularity.conf && \
+    sed -i '/max loop devices/c\max loop devices = 0' /etc/singularity/singularity.conf
 
 # Update & cleanup
 RUN yum -y update && \


### PR DESCRIPTION
This is required to enable ATLAS and SKA to run their own images.
See https://ggus.eu/?mode=ticket_info&ticket_id=138033.

It seems like it used to default to on in the upstream config, but got switch to off by default by accident at some point last year.
See https://github.com/sylabs/singularity/issues/2473

Also see https://bbockelm.github.io/docs/worker-node/install-singularity/#configuring-singularity