### PR TITLE
XRootD: update gateway container configuration for XRootD 5

### DIFF
--- a/xrootd/Dockerfile
+++ b/xrootd/Dockerfile
@@ -8,8 +8,8 @@ RUN groupadd --gid 65432 xrootd && \
 COPY *.repo /etc/yum.repos.d/
 
 # Ceph
-RUN yum -y install ceph-12.2.12-0.el7.x86_64 \
-                   ceph-common-12.2.12-0.el7.x86_64
+RUN yum -y install ceph-14.2.15-0.el7.x86_64 \
+                   ceph-common-14.2.15-0.el7.x86_64
 
 # xrootd
 RUN yum -y install xrootd-ceph \
@@ -21,7 +21,7 @@ RUN yum -y install xrootd-ceph \
                    jemalloc
 
 # For N2N mapping
-RUN yum -y install http://t2.unl.edu/store/osg/3.4/el7/contrib/x86_64/xrootd-cmstfc-1.5.2-3.osg34.el7.x86_64.rpm
+RUN yum -y install http://repos.gridpp.rl.ac.uk/yum/xrootd-cmstfc/el7/xrootd-cmstfc-1.5.2-6.osgup.el7.x86_64.rpm
 
 # Needed by the health-check scripts
 RUN yum -y install openssl

--- a/xrootd/Dockerfile
+++ b/xrootd/Dockerfile
@@ -1,4 +1,10 @@
 FROM centos:7
+ARG XROOTD_VERSION=5.2.0-1
+ARG XRDCEPH_VERSION=5.2.0-1
+ARG CEPH_VERSION=14.2.15-0
+LABEL xrootd-ver=$XROOTD_VERSION
+LABEL xrdceph-ver=$XRDCEPH_VERSION
+LABEL ceph-ver=$CEPH_VERSION
 
 # xrootd user - needs to be consistent with the host
 RUN groupadd --gid 65432 xrootd && \
@@ -7,9 +13,46 @@ RUN groupadd --gid 65432 xrootd && \
 # Repositories
 COPY *.repo /etc/yum.repos.d/
 
+# install versionlock, and configure versionlocks
+RUN yum -y install yum-versionlock
+RUN yum -y versionlock add ceph-${CEPH_VERSION}.el7.x86_64 \
+                           ceph-base-${CEPH_VERSION}.el7.x86_64 \
+                           ceph-common-${CEPH_VERSION}.el7.x86_64 \
+                           ceph-mds-${CEPH_VERSION}.el7.x86_64 \
+                           ceph-mgr-${CEPH_VERSION}.el7.x86_64 \
+                           ceph-mon-${CEPH_VERSION}.el7.x86_64 \
+                           ceph-osd-${CEPH_VERSION}.el7.x86_64 \
+                           ceph-selinux-${CEPH_VERSION}.el7.x86_64 \
+                           libcephfs2-${CEPH_VERSION}.el7.x86_64 \
+                           librados2-${CEPH_VERSION}.el7.x86_64 \
+                           libradosstriper1-${CEPH_VERSION}.el7.x86_64 \
+                           librbd1-${CEPH_VERSION}.el7.x86_64 \
+                           librgw2-${CEPH_VERSION}.el7.x86_64 \
+                           python-ceph-argparse-${CEPH_VERSION}.el7.x86_64 \
+                           python-cephfs-${CEPH_VERSION}.el7.x86_64 \
+                           python-rados-${CEPH_VERSION}.el7.x86_64 \
+                           python-rbd-${CEPH_VERSION}.el7.x86_64 \
+                           python-rgw-${CEPH_VERSION}.el7.x86_64 \
+                           python3-ceph-argparse-${CEPH_VERSION}.el7.x86_64 \
+                           python3-cephfs-${CEPH_VERSION}.el7.x86_64 \
+                           python3-rados-${CEPH_VERSION}.el7.x86_64 \
+                           python3-rbd-${CEPH_VERSION}.el7.x86_64 \
+                           python3-rgw-${CEPH_VERSION}.el7.x86_64 \
+                           xrootd-${XROOTD_VERSION}.el7.x86_64 \
+                           xrootd-client-${XROOTD_VERSION}.el7.x86_64 \
+                           xrootd-client-libs-${XROOTD_VERSION}.el7.x86_64 \
+                           xrootd-libs-${XROOTD_VERSION}.el7.x86_64 \
+                           xrootd-selinux-${XROOTD_VERSION}.el7.x86_64 \
+                           xrootd-server-${XROOTD_VERSION}.el7.x86_64 \
+                           xrootd-server-libs-${XROOTD_VERSION}.el7.x86_64 \
+                           xrootd-ceph-${XRDCEPH_VERSION}.el7.x86_64
+
+RUN yum -y versionlock list 
+
+
 # Ceph
-RUN yum -y install ceph-14.2.15-0.el7.x86_64 \
-                   ceph-common-14.2.15-0.el7.x86_64
+RUN yum -y install ceph \
+                   ceph-common
 
 # xrootd
 RUN yum -y install xrootd-ceph \
@@ -25,6 +68,11 @@ RUN yum -y install http://repos.gridpp.rl.ac.uk/yum/xrootd-cmstfc/el7/xrootd-cms
 
 # Needed by the health-check scripts
 RUN yum -y install openssl
+
+# python3 needed for cephsum script 
+RUN yum -y install xrd-cephsum \
+                   python3 \
+                   python3-rados
 
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/xrootd/ceph-el7-x86_64.repo
+++ b/xrootd/ceph-el7-x86_64.repo
@@ -1,6 +1,6 @@
 [ceph-el7-x86_64]
 name = ceph-el7-x86_64
-baseurl = http://mirrors.gridpp.rl.ac.uk/current/ceph-el7-x86_64/RPMS.luminous/
+baseurl = http://mirrors.gridpp.rl.ac.uk/current/ceph-el7-x86_64/RPMS.nautilus/
 metadata_expire = 7d
 enabled = 1
 gpgcheck = 0

--- a/xrootd/tier1-sl7-local.repo
+++ b/xrootd/tier1-sl7-local.repo
@@ -1,0 +1,9 @@
+[tier1-sl7-local]
+name=tier1-sl7-local
+baseurl=    http://repos.gridpp.rl.ac.uk/yum/local/sl7/
+
+metadata_expire=7d
+enabled=1
+gpgcheck=0
+priority=30
+skip_if_unavailable=0

--- a/xrootd/xrootd-ceph-el7-x86_64.repo
+++ b/xrootd/xrootd-ceph-el7-x86_64.repo
@@ -1,0 +1,8 @@
+[xrootd-ceph-el7-x86_64]
+name = xrootd-ceph-el7-x86_64
+baseurl = http://repos.gridpp.rl.ac.uk/yum/xrootd-ceph/nautilus/el7/x86_64/
+metadata_expire = 7d
+enabled = 1
+gpgcheck = 0
+priority = 30
+skip_if_unavailable = 0

--- a/xrootd/xrootd-el7-x86_64.repo
+++ b/xrootd/xrootd-el7-x86_64.repo
@@ -1,0 +1,8 @@
+[xrootd-el7-x86_64]
+name = xrootd-el7-x86_64
+baseurl = http://mirrors.gridpp.rl.ac.uk/current/xrootd-el7-x86_64/RPMS.xrootd-org/
+metadata_expire = 7d
+enabled = 1
+gpgcheck = 0
+priority = 30
+skip_if_unavailable = 0

--- a/xrootd/xrootd-scd-el7-x86_64.repo
+++ b/xrootd/xrootd-scd-el7-x86_64.repo
@@ -1,8 +1,0 @@
-[xrootd-scd-el7-x86_64]
-name = xrootd-scd-el7-x86_64
-baseurl = http://repos.gridpp.rl.ac.uk/yum/xrootd-scd/luminous/el7/x86_64/
-metadata_expire = 7d
-enabled = 1
-gpgcheck = 0
-priority = 30
-skip_if_unavailable = 0


### PR DESCRIPTION
   * Move to using the community built XRootD 5 RPMs (for all but xrootd-ceph, which is built locally)
   * Move to a local repo for cmstfc (and bump the version to one that exists)
   * Update the Ceph version to match the cluster