### PR TITLE
Add "COPY ceph /opt/lib/ceph" to Dockerfile to obtain new RADOS Strip…

### DIFF
--- a/xrootd/Dockerfile
+++ b/xrootd/Dockerfile
@@ -74,5 +74,7 @@ RUN yum -y install xrd-cephsum \
                    python3 \
                    python3-rados
 
+# Copy directory containing client-side Ceph libraris and dependencies to get new version of RADOS Striper
+COPY ceph /opt/lib/ceph
 COPY docker-entrypoint.sh /
 ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/xrootd/docker-entrypoint.sh
+++ b/xrootd/docker-entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
 export XrdSecSSSKT=/etc/gateway/sss.keytab.grp
 export LD_PRELOAD=/usr/lib64/libjemalloc.so.1
+export LD_LIBRARY_PATH=/opt/lib/ceph
 /usr/bin/xrootd -c /etc/xrootd/xrootd-ceph.cfg -k fifo -s /var/run/xrootd/xrootd-ceph.pid -n ceph


### PR DESCRIPTION
Change Dockerfile to obtain new version of the RADOS Striper library.

Add "export LD_LIBRARY_PATH=/opt/lib/ceph" to docker-entrypoint.sh to load the new RADOS Striper library.