### PR TITLE
Update dockerfile to include the xrootd-voms pkg

### DIFF
--- a/xrootd/Dockerfile
+++ b/xrootd/Dockerfile
@@ -45,7 +45,8 @@ RUN yum -y versionlock add ceph-${CEPH_VERSION}.el7.x86_64 \
                            xrootd-selinux-${XROOTD_VERSION}.el7.noarch \
                            xrootd-server-${XROOTD_VERSION}.el7.x86_64 \
                            xrootd-server-libs-${XROOTD_VERSION}.el7.x86_64 \
-                           xrootd-ceph-${XRDCEPH_VERSION}.el7.x86_64
+                           xrootd-ceph-${XRDCEPH_VERSION}.el7.x86_64 \
+                           xrootd-voms-${XROOTD_VERSION}.el7.x86_64
 
 RUN yum -y versionlock list
 
@@ -61,7 +62,9 @@ RUN yum -y install xrootd-ceph \
                    xrootd-libs \
                    xrootd-server \
                    xrootd-server-libs \
-                   jemalloc
+                   xrootd-voms \
+                   jemalloc 
+                   
 
 # Install custom version of libradosstriper
 # This RPM is it replaces the rados version installed by the ceph package with the lockless version


### PR DESCRIPTION
xrootd-voms package is required for supporting WN authentication using VOMS
During analysis noted that the xrootd-voms-5.3.3-1.el7.x86_64 was not installed and this was causing xrootd-proxy service to error whilst starting.