### PR TITLE
Add bc package required for CMS tests

### DIFF
--- a/docker-c8/Dockerfile
+++ b/docker-c8/Dockerfile
@@ -14,7 +14,8 @@ RUN dnf -y install \
     quota \
     attr \
     tcsh \
-    numactl
+    numactl \
+    bc
 
 # Create all possible pool accounts
 RUN curl -s https://raw.githubusercontent.com/stfc/grid-workernode/master/resources/pool_accounts/create.sh | bash -

--- a/docker-c9/Dockerfile
+++ b/docker-c9/Dockerfile
@@ -14,7 +14,8 @@ RUN dnf -y install \
     quota \
     attr \
     tcsh \
-    numactl
+    numactl \
+    bc
 
 # Create all possible pool accounts
 RUN curl -s https://raw.githubusercontent.com/stfc/grid-workernode/master/resources/pool_accounts/create.sh | bash -


### PR DESCRIPTION
New CMSSGM tests require the `bc` package to pass functional tests.